### PR TITLE
Beléptetés számlálás maradványainak törlése

### DIFF
--- a/src/ISZR.Web/Controllers/HomeController.cs
+++ b/src/ISZR.Web/Controllers/HomeController.cs
@@ -82,7 +82,7 @@ namespace ISZR.Web.Controllers
         /// <param name="user">Felhasználó</param>
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Settings([Bind("UserId,Username,DisplayName,Rank,Genre,Location,Email,Phone,LastLogin,LogonCount,ClassId,PositionId,IsArchived")] User user)
+        public async Task<IActionResult> Settings([Bind("UserId,Username,DisplayName,Rank,Genre,Location,Email,Phone,LastLogin,ClassId,PositionId,IsArchived")] User user)
         {
             // Megadott értékek ellenőrzése
             if (ModelState.IsValid)

--- a/src/ISZR.Web/Controllers/RequestsController.cs
+++ b/src/ISZR.Web/Controllers/RequestsController.cs
@@ -197,7 +197,7 @@ namespace ISZR.Web.Controllers
         /// <param name="user">Új felhasználóval kapcsolatos adatok</param>
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> NewUserAccess(int? selectedGroup, [Bind("UserId,Username,DisplayName,Rank,Genre,Location,Email,Phone,LastLogin,LogonCount,ClassId,PositionId,IsArchived")] User user)
+        public async Task<IActionResult> NewUserAccess(int? selectedGroup, [Bind("UserId,Username,DisplayName,Rank,Genre,Location,Email,Phone,LastLogin,ClassId,PositionId,IsArchived")] User user)
         {
             // Új felhasználó adatainak meglétének ellenőrzése
             if (user == null || selectedGroup == null) return Forbid();

--- a/src/ISZR.Web/Controllers/UsersController.cs
+++ b/src/ISZR.Web/Controllers/UsersController.cs
@@ -116,7 +116,7 @@ namespace ISZR.Web.Controllers
         /// <param name="user">Felhasználó új megadott értékei</param>
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("UserId,Username,DisplayName,Rank,Genre,Location,Email,Phone,LastLogin,LogonCount,ClassId,PositionId,IsArchived")] User user)
+        public async Task<IActionResult> Create([Bind("UserId,Username,DisplayName,Rank,Genre,Location,Email,Phone,LastLogin,ClassId,PositionId,IsArchived")] User user)
         {
             // Megadott értékek ellenőrzése
             if (ModelState.IsValid)
@@ -187,7 +187,7 @@ namespace ISZR.Web.Controllers
         /// <param name="user">Felhasználó új értékei</param>
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(int id, [Bind("UserId,Username,DisplayName,Rank,Genre,Location,Email,Phone,LastLogin,LogonCount,ClassId,PositionId,IsArchived")] User user)
+        public async Task<IActionResult> Edit(int id, [Bind("UserId,Username,DisplayName,Rank,Genre,Location,Email,Phone,LastLogin,ClassId,PositionId,IsArchived")] User user)
         {
             // Azonosítók meglétének ellenőrzése
             if (id != user.UserId) return NotFound();

--- a/src/ISZR.Web/ISZR.Web.csproj
+++ b/src/ISZR.Web/ISZR.Web.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <AssemblyVersion>23.7.16.19</AssemblyVersion>
-    <FileVersion>23.7.16.19</FileVersion>
+    <AssemblyVersion>23.7.17.1</AssemblyVersion>
+    <FileVersion>23.7.17.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Az új azonosítási rendszer már nem igényel beléptetési számlálót. Ezért annak maradványainak törlésre kerültek.